### PR TITLE
support roles with custom paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,7 +144,7 @@ runs:
           exit 0
         fi
 
-        if echo "$value" | grep -Eqv "^arn:aws:iam::[0-9]{9,12}:role(\/|\/[\x21-\x7E]{1,510}\/)[a-zA-z0-9_+=,.@-]{1,64}$"; then
+        if echo "$value" | grep -Eqv "^arn:aws:iam::[0-9]{9,12}:role(\/[a-zA-Z0-9_+=,.@\/-]{1,510}\/|\/)[a-zA-z0-9_+=,.@-]{1,64}$"; then
           echo "Value for Role To Assume is invalid"
           exit 1
         fi

--- a/action.yml
+++ b/action.yml
@@ -144,7 +144,7 @@ runs:
           exit 0
         fi
 
-        if echo "$value" | grep -Eqv "^arn:aws:iam::[0-9]{9,12}:role(\/service-role\/|\/)[a-zA-z0-9_+=,.@-]{1,64}$"; then
+        if echo "$value" | grep -Eqv "^arn:aws:iam::[0-9]{9,12}:role(\/|\/[\x21-\x7E]{1,510}\/)[a-zA-z0-9_+=,.@-]{1,64}$"; then
           echo "Value for Role To Assume is invalid"
           exit 1
         fi


### PR DESCRIPTION
Handle custom IAM Role Path in the role validation regex.

Based on the [IAM Role API documentation](https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html), and the corresponding [CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#aws-resource-iam-role-properties), a surprising range of ASCII characters are supported:
> This parameter allows (through its regex pattern) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (\u0021) through the DEL character (\u007F), including most punctuation characters, digits, and upper and lowercased letters.

I changed the range to end on `\x7E` instead of `\x7F`, because though the `DEL` character is supported by the API, it seems like a Bad Idea to allow it in a bash script.